### PR TITLE
Turn tests deployments into jobs

### DIFF
--- a/k8s-templates/fabric-deployment-test-fabric-abac.yaml
+++ b/k8s-templates/fabric-deployment-test-fabric-abac.yaml
@@ -13,20 +13,13 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1
+kind: Job
 metadata:
   namespace: %DOMAIN%
   name: test-fabric
 spec:
-  replicas: 1
-  strategy: {}
-  selector:
-    matchLabels:
-       app: hyperledger
-       role: client
-       org: %ORG%
-       name: test-fabric
+  backoffLimit: 3
   template:
     metadata:
       labels:
@@ -35,6 +28,7 @@ spec:
        org: %ORG%
        name: test-fabric
     spec:
+     restartPolicy: "Never"
      containers:
        - name: test-fabric
          image: hyperledger/fabric-tools:%FABRIC_TAG%
@@ -42,7 +36,7 @@ spec:
           - name: GOPATH
             value: /opt/gopath
          command: ["sh"]
-         args:  ["-c", "/scripts/test-fabric-abac.sh 2>&1; while true; do sleep 90; done;"]
+         args:  ["-c", "/scripts/test-fabric-abac.sh"]
          volumeMounts:
           - mountPath: /scripts
             name: rca-scripts

--- a/k8s-templates/fabric-deployment-test-fabric-marbles-workshop.yaml
+++ b/k8s-templates/fabric-deployment-test-fabric-marbles-workshop.yaml
@@ -13,20 +13,13 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1
+kind: Job
 metadata:
   namespace: %DOMAIN%
   name: test-fabric-marbles-workshop
 spec:
-  replicas: 1
-  strategy: {}
-  selector:
-    matchLabels:
-       app: hyperledger
-       role: client
-       org: %ORG%
-       name: test-fabric-marbles-workshop
+  backoffLimit: 3
   template:
     metadata:
       labels:
@@ -35,6 +28,7 @@ spec:
        org: %ORG%
        name: test-fabric-marbles-workshop
     spec:
+     restartPolicy: "Never"
      containers:
        - name: test-fabric-marbles-workshop
          image: hyperledger/fabric-tools:%FABRIC_TAG%
@@ -42,7 +36,7 @@ spec:
           - name: GOPATH
             value: /opt/gopath
          command: ["sh"]
-         args:  ["-c", "/scripts/test-fabric-marbles-workshop.sh 2>&1; while true; do sleep 90; done;"]
+         args:  ["-c", "/scripts/test-fabric-marbles-workshop.sh"]
          volumeMounts:
           - mountPath: /scripts
             name: rca-scripts

--- a/k8s-templates/fabric-deployment-test-fabric-marbles.yaml
+++ b/k8s-templates/fabric-deployment-test-fabric-marbles.yaml
@@ -13,20 +13,13 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1
+kind: Job
 metadata:
   namespace: %DOMAIN%
   name: test-fabric-marbles
 spec:
-  replicas: 1
-  strategy: {}
-  selector:
-    matchLabels:
-       app: hyperledger
-       role: client
-       org: %ORG%
-       name: test-fabric-marbles
+  backoffLimit: 3
   template:
     metadata:
       labels:
@@ -35,6 +28,7 @@ spec:
        org: %ORG%
        name: test-fabric-marbles
     spec:
+     restartPolicy: "Never"
      containers:
        - name: test-fabric-marbles
          image: hyperledger/fabric-tools:%FABRIC_TAG%
@@ -42,7 +36,7 @@ spec:
           - name: GOPATH
             value: /opt/gopath
          command: ["sh"]
-         args:  ["-c", "/scripts/test-fabric-marbles.sh 2>&1; while true; do sleep 90; done;"]
+         args:  ["-c", "/scripts/test-fabric-marbles.sh"]
          volumeMounts:
           - mountPath: /scripts
             name: rca-scripts


### PR DESCRIPTION
*Issue #, if available:* Turn tests into Jobs #4 

*Description of changes:*
- Files that match _/k8s_templates/fabric-deployment-test-fabric*_ have changed their type from `deployment` to `job`.
- In the same files, restart policy has been set to 'Never', back-off limit to 3 and specific fields from spec have been removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.