### PR TITLE
Fix ABAC test

### DIFF
--- a/scripts/test-fabric-abac.sh
+++ b/scripts/test-fabric-abac.sh
@@ -215,7 +215,7 @@ function chaincodeQuery {
    while test "$(($(date +%s)-starttime))" -lt "$QUERY_TIMEOUT"; do
       sleep 1
       peer chaincode query -C $CHANNEL_NAME -n $CHAINCODE_NAME -c '{"Args":["query","a"]}' >& log-abac.txt
-      VALUE=$(cat log-abac.txt | awk '/Query Result/ {print $NF}')
+      VALUE=$(cat log-abac.txt | awk '{print $1}')
       if [ $? -eq 0 -a "$VALUE" = "$1" ]; then
          log "Query of channel '$CHANNEL_NAME' on peer '$PEER_HOST' was successful"
          set -e


### PR DESCRIPTION
*Issue #, if available:*  The pod gives an error on this line and does not complete the tests. #10 

*Description of changes:*
As the awk was failing because of the abscence of "Query Result" in the log, the command has been modified to prevent the error.

_IMPORTANT_ This has not been tested and it is just a pull request that introduces the change proposed by @binnyrs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
