### PR TITLE
Make peers persistent

### DIFF
--- a/fabric-main/gen-fabric-functions.sh
+++ b/fabric-main/gen-fabric-functions.sh
@@ -435,9 +435,9 @@ function genPeers {
             log "Port assigned to peer: peer$COUNT-$ORG is $PORTCHAIN"
             # for the 1st peer we generate a peer with no client-side TLS, i.e. no mutual TLS
             if [ $COUNT -eq 1 ]; then
-                sed -e "s/%ORG%/${ORG}/g" -e "s/%DOMAIN%/${DOMAIN}/g" -e "s/%NUM%/${COUNT}/g" -e "s/%PORTEND%/${PORTEND}/g" -e "s/%PORTCHAIN%/${PORTCHAIN}/g" -e "s/%FABRIC_TAG%/${FABRIC_TAG}/g" ${K8STEMPLATES}/fabric-deployment-peer-noclienttls.yaml > ${K8SYAML}/fabric-deployment-peer$COUNT-$ORG.yaml
+                sed -e "s/%PEER_SIZE%/${PEER_SIZE}/g" -e "s/%PEER_DB_SIZE%/${PEER_DB_SIZE}/g" -e "s/%ORG%/${ORG}/g" -e "s/%DOMAIN%/${DOMAIN}/g" -e "s/%NUM%/${COUNT}/g" -e "s/%PORTEND%/${PORTEND}/g" -e "s/%PORTCHAIN%/${PORTCHAIN}/g" -e "s/%FABRIC_TAG%/${FABRIC_TAG}/g" ${K8STEMPLATES}/fabric-deployment-peer-noclienttls.yaml > ${K8SYAML}/fabric-deployment-peer$COUNT-$ORG.yaml
             else
-                sed -e "s/%ORG%/${ORG}/g" -e "s/%DOMAIN%/${DOMAIN}/g" -e "s/%NUM%/${COUNT}/g" -e "s/%PORTEND%/${PORTEND}/g" -e "s/%PORTCHAIN%/${PORTCHAIN}/g" -e "s/%FABRIC_TAG%/${FABRIC_TAG}/g" ${K8STEMPLATES}/fabric-deployment-peer.yaml > ${K8SYAML}/fabric-deployment-peer$COUNT-$ORG.yaml
+                sed -e "s/%PEER_SIZE%/${PEER_SIZE}/g" -e "s/%PEER_DB_SIZE%/${PEER_DB_SIZE}/g" -e "s/%ORG%/${ORG}/g" -e "s/%DOMAIN%/${DOMAIN}/g" -e "s/%NUM%/${COUNT}/g" -e "s/%PORTEND%/${PORTEND}/g" -e "s/%PORTCHAIN%/${PORTCHAIN}/g" -e "s/%FABRIC_TAG%/${FABRIC_TAG}/g" ${K8STEMPLATES}/fabric-deployment-peer.yaml > ${K8SYAML}/fabric-deployment-peer$COUNT-$ORG.yaml
             fi
             COUNT=$((COUNT+1))
         done

--- a/k8s-templates/fabric-deployment-peer-noclienttls.yaml
+++ b/k8s-templates/fabric-deployment-peer-noclienttls.yaml
@@ -14,13 +14,13 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   namespace: %DOMAIN%
   name: peer%NUM%-%ORG%
 spec:
+  serviceName: peer%NUM%-%ORG%
   replicas: 1
-  strategy: {}
   selector:
     matchLabels:
        app: hyperledger
@@ -40,6 +40,9 @@ spec:
          image: hyperledger/fabric-couchdb:latest
          ports:
           - containerPort: 5984
+         volumeMounts:
+         - mountPath: /opt/couchdb/data
+           name: database
        - name: peer%NUM%-%ORG%
          image: hyperledger/fabric-peer:%FABRIC_TAG%
          env:
@@ -122,6 +125,8 @@ spec:
             name: rca-data
           - mountPath: /host/var/run/
             name: run
+          - mountPath: /var/hyperledger/production
+            name: production
      volumes:
        - name: rca-scripts
          persistentVolumeClaim:
@@ -132,6 +137,23 @@ spec:
        - name: run
          hostPath:
            path: /run
+  volumeClaimTemplates:
+  - metadata:
+      name: production
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: gp2
+      resources:
+        requests:
+          storage: %PEER_SIZE%
+  - metadata:
+      name: database
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: gp2
+      resources:
+        requests:
+          storage: %PEER_DB_SIZE%
 
 ---
 apiVersion: v1

--- a/k8s-templates/fabric-deployment-peer.yaml
+++ b/k8s-templates/fabric-deployment-peer.yaml
@@ -14,13 +14,13 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   namespace: %DOMAIN%
   name: peer%NUM%-%ORG%
 spec:
+  serviceName: peer%NUM%-%ORG%
   replicas: 1
-  strategy: {}
   selector:
     matchLabels:
        app: hyperledger
@@ -40,6 +40,9 @@ spec:
          image: hyperledger/fabric-couchdb:latest
          ports:
           - containerPort: 5984
+         volumeMounts:
+         - mountPath: /opt/couchdb/data
+           name: database
        - name: peer%NUM%-%ORG%
          image: hyperledger/fabric-peer:%FABRIC_TAG%
          env:
@@ -122,6 +125,8 @@ spec:
             name: rca-data
           - mountPath: /host/var/run/
             name: run
+          - mountPath: /var/hyperledger/production
+            name: production
      volumes:
        - name: rca-scripts
          persistentVolumeClaim:
@@ -132,6 +137,23 @@ spec:
        - name: run
          hostPath:
            path: /run
+  volumeClaimTemplates:
+  - metadata:
+      name: production
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: gp2
+      resources:
+        requests:
+          storage: %PEER_SIZE%
+  - metadata:
+      name: database
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: gp2
+      resources:
+        requests:
+          storage: %PEER_DB_SIZE%
 
 ---
 apiVersion: v1

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -72,6 +72,10 @@ ADMINCERTS=true
 # 3) for client applications connecting to the orderer remotely, without TLS. An NLB is required that handles
 NUM_ORDERERS=3
 
+# Size of the volumes where peers data is stored
+PEER_SIZE="200Gi"
+PEER_DB_SIZE="200Gi"
+
 # The volume mount to share data between containers
 DATA=data
 


### PR DESCRIPTION
*Issue #, if available:* Make peers persistent #7 

*Description of changes:*
Allow peers to store data from hyperledger and couchdb persistently. To achive this Deployments have been turned into StatefulSets and two additional EBS ara used by peer. By default, these volumes have a size of 200Gi.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
