### PR TITLE
Make orderers persistent

### DIFF
--- a/fabric-main/gen-fabric-functions.sh
+++ b/fabric-main/gen-fabric-functions.sh
@@ -362,13 +362,13 @@ function genOrderer {
             # for the 2nd orderer we generate an orderer with no server-side TLS
             # for the 3rd orderer we generate an orderer with no client-side TLS, i.e. no mutual TLS
             if [ $COUNT -eq 2 ]; then
-                sed -e "s/%ORG%/${ORG}/g" -e "s/%DOMAIN%/${DOMAIN}/g" -e "s/%NUM%/${COUNT}/g" -e "s/%PORT%/${ordererport}/g" -e "s/%FABRIC_TAG%/${FABRIC_TAG}/g" ${K8STEMPLATES}/fabric-deployment-orderer-noservertls.yaml > ${K8SYAML}/fabric-deployment-orderer$COUNT-$ORG.yaml
+                sed -e "s/%ORDERER_SIZE%/${ORDERER_SIZE}/g" -e "s/%ORG%/${ORG}/g" -e "s/%DOMAIN%/${DOMAIN}/g" -e "s/%NUM%/${COUNT}/g" -e "s/%PORT%/${ordererport}/g" -e "s/%FABRIC_TAG%/${FABRIC_TAG}/g" ${K8STEMPLATES}/fabric-deployment-orderer-noservertls.yaml > ${K8SYAML}/fabric-deployment-orderer$COUNT-$ORG.yaml
                 sed -e "s/%ORG%/${ORG}/g" -e "s/%DOMAIN%/${DOMAIN}/g" -e "s/%NUM%/${COUNT}/g" ${K8STEMPLATES}/fabric-nlb-orderer.yaml > ${K8SYAML}/fabric-nlb-orderer$COUNT-$ORG.yaml
             elif [ $COUNT -eq 3 ]; then
-                sed -e "s/%ORG%/${ORG}/g" -e "s/%DOMAIN%/${DOMAIN}/g" -e "s/%NUM%/${COUNT}/g" -e "s/%PORT%/${ordererport}/g" -e "s/%FABRIC_TAG%/${FABRIC_TAG}/g" ${K8STEMPLATES}/fabric-deployment-orderer-noclienttls.yaml > ${K8SYAML}/fabric-deployment-orderer$COUNT-$ORG.yaml
+                sed -e "s/%ORDERER_SIZE%/${ORDERER_SIZE}/g" -e "s/%ORG%/${ORG}/g" -e "s/%DOMAIN%/${DOMAIN}/g" -e "s/%NUM%/${COUNT}/g" -e "s/%PORT%/${ordererport}/g" -e "s/%FABRIC_TAG%/${FABRIC_TAG}/g" ${K8STEMPLATES}/fabric-deployment-orderer-noclienttls.yaml > ${K8SYAML}/fabric-deployment-orderer$COUNT-$ORG.yaml
                 sed -e "s/%ORG%/${ORG}/g" -e "s/%DOMAIN%/${DOMAIN}/g" -e "s/%NUM%/${COUNT}/g" ${K8STEMPLATES}/fabric-nlb-orderer.yaml > ${K8SYAML}/fabric-nlb-orderer$COUNT-$ORG.yaml
             else
-                sed -e "s/%ORG%/${ORG}/g" -e "s/%DOMAIN%/${DOMAIN}/g" -e "s/%NUM%/${COUNT}/g" -e "s/%PORT%/${ordererport}/g" -e "s/%FABRIC_TAG%/${FABRIC_TAG}/g" ${K8STEMPLATES}/fabric-deployment-orderer.yaml > ${K8SYAML}/fabric-deployment-orderer$COUNT-$ORG.yaml
+                sed -e "s/%ORDERER_SIZE%/${ORDERER_SIZE}/g" -e "s/%ORG%/${ORG}/g" -e "s/%DOMAIN%/${DOMAIN}/g" -e "s/%NUM%/${COUNT}/g" -e "s/%PORT%/${ordererport}/g" -e "s/%FABRIC_TAG%/${FABRIC_TAG}/g" ${K8STEMPLATES}/fabric-deployment-orderer.yaml > ${K8SYAML}/fabric-deployment-orderer$COUNT-$ORG.yaml
                 sed -e "s/%ORG%/${ORG}/g" -e "s/%DOMAIN%/${DOMAIN}/g" -e "s/%NUM%/${COUNT}/g" ${K8STEMPLATES}/fabric-nlb-orderer.yaml > ${K8SYAML}/fabric-nlb-orderer$COUNT-$ORG.yaml
             fi
             COUNT=$((COUNT+1))

--- a/k8s-templates/fabric-deployment-orderer-noclienttls.yaml
+++ b/k8s-templates/fabric-deployment-orderer-noclienttls.yaml
@@ -14,13 +14,13 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   namespace: %DOMAIN%
   name: orderer%NUM%-%ORG%
 spec:
+  serviceName: orderer%NUM%-%ORG%
   replicas: 1
-  strategy: {}
   selector:
     matchLabels:
        app: hyperledger
@@ -98,6 +98,8 @@ spec:
             name: rca-scripts
           - mountPath: /data
             name: rca-data
+          - mountPath: /var/hyperledger/production
+            name: production
      volumes:
        - name: orderer
          persistentVolumeClaim:
@@ -108,6 +110,15 @@ spec:
        - name: rca-data
          persistentVolumeClaim:
              claimName: rca-data-%ORG%-pvc
+  volumeClaimTemplates:
+  - metadata:
+     name: production
+    spec:
+     accessModes: [ "ReadWriteOnce" ]
+     storageClassName: gp2
+     resources:
+       requests:
+         storage: %ORDERER_SIZE%
 
 ---
 apiVersion: v1

--- a/k8s-templates/fabric-deployment-orderer-noservertls.yaml
+++ b/k8s-templates/fabric-deployment-orderer-noservertls.yaml
@@ -14,13 +14,13 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   namespace: %DOMAIN%
   name: orderer%NUM%-%ORG%
 spec:
+  serviceName: orderer%NUM%-%ORG%
   replicas: 1
-  strategy: {}
   selector:
     matchLabels:
        app: hyperledger
@@ -98,6 +98,8 @@ spec:
             name: rca-scripts
           - mountPath: /data
             name: rca-data
+          - mountPath: /var/hyperledger/production
+            name: production
      volumes:
        - name: orderer
          persistentVolumeClaim:
@@ -108,6 +110,15 @@ spec:
        - name: rca-data
          persistentVolumeClaim:
              claimName: rca-data-%ORG%-pvc
+  volumeClaimTemplates:
+  - metadata:
+     name: production
+    spec:
+     accessModes: [ "ReadWriteOnce" ]
+     storageClassName: gp2
+     resources:
+       requests:
+         storage: %ORDERER_SIZE%
 
 ---
 apiVersion: v1

--- a/k8s-templates/fabric-deployment-orderer.yaml
+++ b/k8s-templates/fabric-deployment-orderer.yaml
@@ -14,13 +14,13 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   namespace: %DOMAIN%
   name: orderer%NUM%-%ORG%
 spec:
-  replicas: 1
-  strategy: {}
+  serviceName: orderer%NUM%-%ORG%
+  replicas: 2
   selector:
     matchLabels:
        app: hyperledger
@@ -98,6 +98,8 @@ spec:
             name: rca-scripts
           - mountPath: /data
             name: rca-data
+          - mountPath: /var/hyperledger/production
+            name: production
      volumes:
        - name: orderer
          persistentVolumeClaim:
@@ -108,6 +110,15 @@ spec:
        - name: rca-data
          persistentVolumeClaim:
              claimName: rca-data-%ORG%-pvc
+  volumeClaimTemplates:
+  - metadata:
+     name: production
+    spec:
+     accessModes: [ "ReadWriteOnce" ]
+     storageClassName: gp2
+     resources:
+       requests:
+         storage: %ORDERER_SIZE%
 
 ---
 apiVersion: v1

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -72,6 +72,9 @@ ADMINCERTS=true
 # 3) for client applications connecting to the orderer remotely, without TLS. An NLB is required that handles
 NUM_ORDERERS=3
 
+# Size of the volumes where orderers data is stored
+ORDERER_SIZE="200Gi"
+
 # The volume mount to share data between containers
 DATA=data
 


### PR DESCRIPTION
*Issue #, if available:* Make orderers persistent #6  

*Description of changes:*
Allow orderers to store data from hyperledger persistently. To achive this Deployments have been turned into StatefulSets and one additional EBS is used by orderer. By default, these volumes have a size of 200Gi.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
