### PR TITLE
Store Kafka values in the environment file

### DIFF
--- a/fabric-main/start-kafka.sh
+++ b/fabric-main/start-kafka.sh
@@ -84,7 +84,7 @@ function startExternalELB {
     done
     echo "Updating 50kafka-aws.yml and ${SCRIPTS}/gen-channel-artifacts.sh with hostname: ${ELBHOSTNAME}:${ELBHOSTPORT}"
     #update 50kafka.yml with the hostname. This is used in the external Kafka broker address
-    sed -e "s/%ELBHOSTNAME%/${ELBHOSTNAME}:${ELBHOSTPORT}/g" kafka/50kafka.yml > kafka/50kafka-aws.yml
+    sed -e "s/%ELBHOSTNAME%/${ELBHOSTNAME}:${ELBHOSTPORT}/g" -e "s/%KAFKA_SIZE%/${KAFKA_SIZE}/g" -e "s/%KAFKA_REPLICAS%/${KAFKA_REPLICAS}/g" kafka/50kafka.yml > kafka/50kafka-aws.yml
     #update env.sh with the Kafka Broker external hostname. This will be used in scripts/gen-channel-artifacts.sh, and
     # add the broker name to configtx.yaml
     echo "Updating env.sh with Kafka Broker endpoint: ${ELBHOSTNAME}"

--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
       app: kafka
   serviceName: "broker"
-  replicas: 3
+  replicas: %KAFKA_REPLICAS%
   updateStrategy:
     type: OnDelete
   template:
@@ -111,4 +111,4 @@ spec:
       storageClassName: kafka-broker
       resources:
         requests:
-          storage: 200Gi
+          storage: %KAFKA_SIZE%

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -72,6 +72,12 @@ ADMINCERTS=true
 # 3) for client applications connecting to the orderer remotely, without TLS. An NLB is required that handles
 NUM_ORDERERS=3
 
+# Number of kafka nodes
+KAFKA_REPLICAS=3
+
+# Size of the volumes where kafka data is stored
+KAFKA_SIZE="200Gi"
+
 # The volume mount to share data between containers
 DATA=data
 


### PR DESCRIPTION
*Issue #, if available:* Set kafka variables in the environment file #8

*Description of changes:*
Number of replicas and volume sizes are now in the env.sh file. This way developers can easily modify those variables.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
